### PR TITLE
ci: run stmobile-validate on JDK 17 (unify with CI.yml)

### DIFF
--- a/.github/workflows/stmobile-validate.yml
+++ b/.github/workflows/stmobile-validate.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 


### PR DESCRIPTION
## What
Flip `stmobile-validate.yml` from JDK 11 to **JDK 17**, so both fork CI workflows agree on the JDK (`CI.yml` already uses 17).

## Why
The two workflows disagreed on JDK version (CI.yml=17, stmobile-validate=11). Unifying on JDK 17 aligns the fork's local + CI toolchain with the modern LTS baseline upstream uses.

## Scope (deliberately minimal)
- **No** Gradle / AGP / Kotlin upgrade. Stays on Gradle 7.5 + AGP 7.4.2 + Kotlin 1.8.10 (which all run fine on JDK 17).
- **No** bytecode-target change — all 48 modules keep `sourceCompatibility/targetCompatibility = VERSION_1_8`. Only the build JVM moves.
- Does **not** reverse the re-base's deliberate drop of the Gradle 8.7 upgrade; adds no upstream-merge surface.
- The two workflows stay **separate** (PR-trigger + upstream-mergeability) — only the JDK version is unified.

## Verification
- Local JDK 17.0.19: `assembleStmobileDebug` + `assembleStmobileRelease` both build clean, **no `--add-opens` needed**.
- Release APK reinstalls in place over alpha3 and launches on device `R3GL3069JMZ` — no `UnsatisfiedLinkError` / Conscrypt crash, `.so` files present.
- `CI.yml`'s green JDK-17 history (building `stbeta`) already proved the stack compiles on 17 in Actions.

This PR exercises `stmobile-validate`'s `pull_request` trigger on JDK 17 — that run going green is the final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)