### PR TITLE
Upstream sync 2026-05-30 — clean merge (Conscrypt all-devices + MediaServiceCore bump)

### DIFF
--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/main/MainApplication.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/main/MainApplication.java
@@ -1,10 +1,7 @@
 package com.liskovsoft.smartyoutubetv2.tv.ui.main;
 
-import android.os.Build;
-
 import androidx.multidex.MultiDexApplication;
 
-import com.liskovsoft.sharedutils.helpers.AppInfoHelpers;
 import com.liskovsoft.sharedutils.helpers.Helpers;
 import com.liskovsoft.smartyoutubetv2.common.app.models.data.BrowseSection;
 import com.liskovsoft.smartyoutubetv2.common.app.presenters.BrowsePresenter;
@@ -56,12 +53,12 @@ public class MainApplication extends MultiDexApplication { // fix: Didn't find c
         // ByeByeDPI fix
         // https://android-review.googlesource.com/c/platform/external/conscrypt/+/89408/
         // NOTE: Android 10+ (API 29+) uses system Conscrypt TLS; custom Security providers are unnecessary
-        if (Build.VERSION.SDK_INT < 29 && Conscrypt.isAvailable()) {
-            Security.insertProviderAt(Conscrypt.newProvider(), 1);
-        }
-        //if (Conscrypt.isAvailable()) {
+        //if (Build.VERSION.SDK_INT < 29 && Conscrypt.isAvailable()) {
         //    Security.insertProviderAt(Conscrypt.newProvider(), 1);
         //}
+        if (Conscrypt.isAvailable()) {
+            Security.insertProviderAt(Conscrypt.newProvider(), 1);
+        }
 
         setupGlobalExceptionHandler();
         setupViewManager();


### PR DESCRIPTION
Automatic merge of `upstream/master` into `master` — clean, no conflicts.

(Opened manually by the repo owner. The daily `upstream-sync.yml` correctly
detected, merged and pushed branch `upstream-sync/2026-05-30`, but its final
`gh pr create` step is blocked — the scoped Actions `GITHUB_TOKEN` is refused
`createPullRequest` on this fork even with "Allow GitHub Actions to create and
approve pull requests" enabled. Workflow needs a PAT or a degraded fallback;
tracked separately.)

## New upstream commits since last merge
```
11ae45267 Conscrypt: enable for all devices
```

## ⚠ Review before merging — NOT a rubber stamp
This single commit:
- **Reverses the alpha3 Conscrypt crash-fix gating.** alpha3 shipped
  `if (Build.VERSION.SDK_INT < 29 && Conscrypt.isAvailable())`; this commit
  re-enables `Conscrypt.newProvider()` for **all** devices.
- **Bumps the `MediaServiceCore` submodule** (`a58677e70` -> `43da36fda`) —
  presumably where the real fix that makes all-device Conscrypt safe lives.
- Touches `smarttubetv/src/main/java/.../tv/ui/main/MainApplication.java`, near
  integration point #3 (the `protected setupViewManager` widening — unaffected).

**Required before merge:** device smoke test on a real phone — playback,
sign-in, and specifically an Android 8 / API < 29 launch path (the case alpha3's
gating protected). Confirm the 3 integration points are intact; `stmobile-validate`
will check them automatically on this PR.

_Branch generated by .github/workflows/upstream-sync.yml; PR opened manually._
